### PR TITLE
fix: resolve font renderer issues

### DIFF
--- a/src/main/java/club/sk1er/patcher/hooks/FontRendererHook.java
+++ b/src/main/java/club/sk1er/patcher/hooks/FontRendererHook.java
@@ -189,6 +189,11 @@ public final class FontRendererHook {
         final Deque<RenderPair> underline = new LinkedList<>();
         final Deque<RenderPair> strikethrough = new LinkedList<>();
 
+        value.setLastRed(red);
+        value.setLastGreen(green);
+        value.setLastBlue(blue);
+        value.setLastAlpha(alpha);
+
         for (int messageChar = 0; messageChar < text.length(); ++messageChar) {
             char letter = text.charAt(messageChar);
 
@@ -306,7 +311,8 @@ public final class FontRendererHook {
                     adjustOrAppend(underline, this.fontRenderer.posX, effectiveWidth, value.getLastRed(), value.getLastGreen(), value.getLastBlue(), value.getLastAlpha());
                 }
 
-                this.fontRenderer.posX += effectiveWidth;
+                // Intentional cast to int to round down, see FontRenderer#doDraw
+                this.fontRenderer.posX += (int) effectiveWidth;
             }
         }
 


### PR DESCRIPTION
Some notes on the fix for #7:
This fixes situations like `§mTest`, `§6Test1 §r§mTest2` already works.
The reason this is necessary is because `FontRenderer#renderString` sets the color based on the passed color, then calls `FontRenderer#renderStringAtPos` (which patcher hooks). However patcher does not update the lastColor/Alpha of a `CachedString` until a color code or reset code is hit. This means that the strikethrough in the first case above does render, but with alpha 0 (completely transparent). By initializing the lastColor/Alpha we resolve this issue.