### PR TITLE
change: update MinecraftForge repo url

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@ buildscript {
     repositories {
         mavenCentral()
         maven { url 'https://jitpack.io' }
-        maven { url "https://files.minecraftforge.net/maven" }
+        maven { url "https://maven.minecraftforge.net/" }
         maven { url "https://oss.sonatype.org/content/repositories/snapshots/" }
         maven { url "https://repo.sk1er.club/repository/maven-public" }
     }


### PR DESCRIPTION
Updated as per [asbyth's guide on 1.8.9 forge modding](https://gist.github.com/asbyth/ba2cd9b66925f2437bbcfcd884d60af7)