### PR TITLE
fix: prevent entity culling from sometimes causing render issues with other mods

### DIFF
--- a/src/main/java/club/sk1er/patcher/util/world/render/culling/EntityCulling.java
+++ b/src/main/java/club/sk1er/patcher/util/world/render/culling/EntityCulling.java
@@ -23,6 +23,7 @@ import net.minecraft.entity.player.EntityPlayer;
 import net.minecraft.scoreboard.Team;
 import net.minecraft.util.AxisAlignedBB;
 import net.minecraftforge.client.event.RenderLivingEvent;
+import net.minecraftforge.fml.common.eventhandler.EventPriority;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.TickEvent;
 import org.lwjgl.opengl.GL11;
@@ -193,7 +194,7 @@ public class EntityCulling {
      *
      * @param event {@link RenderLivingEvent.Pre<EntityLivingBase>}
      */
-    @SubscribeEvent
+    @SubscribeEvent(priority = EventPriority.HIGHEST)
     public void shouldRenderEntity(RenderLivingEvent.Pre<EntityLivingBase> event) {
         if (!PatcherConfig.entityCulling || !shouldPerformCulling) {
             return;


### PR DESCRIPTION
some mods, like Lucraft: Core (included in InsaneCraft), push the gl matrix in renderlivingevent.pre and pop it again in renderlivingevent.post. before, entity culling would cancel the event after renderlivingevent.pre was processed by the other mod (and thus the gl stack was pushed), causing renderlivingevent.post not to get pushed, and the gl stack to not be popped. this caused severe render issues and opengl stack overflows. setting the entity culling handler to the highest priority resolves this issue.