### PR TITLE
Update LinuxKeybindFix so it works for azerty

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -71,6 +71,14 @@ public class PatcherConfig extends Vigilant {
     )
     public static boolean fixedAlexArms = true;
 
+    @Property(
+        type = PropertyType.SELECTOR, name = "Keyboard layout",
+        description = "The layout of your keyboard, used to fix input bugs accordingly.",
+        category = "Miscellaneous", subcategory = "Linux", hidden = !SystemUtils.IS_OS_LINUX,
+        options = ["QWERTY", "AZERTY"]
+    )
+    public static int KeyboardLayout = 0
+
     // MISCELLANEOUS
 
     @Property(

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -72,7 +72,7 @@ public class PatcherConfig extends Vigilant {
     public static boolean fixedAlexArms = true;
 
     @Property(
-        type = PropertyType.SELECTOR, name = "Keyboard layout",
+        type = PropertyType.SELECTOR, name = "Keyboard Layout",
         description = "The layout of your keyboard, used to fix input bugs accordingly.",
         category = "Bug Fixes", subcategory = "Linux",
         options = {"QWERTY", "AZERTY"}

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -74,10 +74,11 @@ public class PatcherConfig extends Vigilant {
     @Property(
         type = PropertyType.SELECTOR, name = "Keyboard layout",
         description = "The layout of your keyboard, used to fix input bugs accordingly.",
-        category = "Miscellaneous", subcategory = "Linux", hidden = !SystemUtils.IS_OS_LINUX,
-        options = ["QWERTY", "AZERTY"]
+        category = "Bug Fixes", subcategory = "Linux",
+        options = {"QWERTY", "AZERTY"}
     )
-    public static int KeyboardLayout = 0
+    public static int KeyboardLayout = 0;
+
 
     // MISCELLANEOUS
 
@@ -1324,6 +1325,8 @@ public class PatcherConfig extends Vigilant {
                 "leftHandInFirstPerson", "extendedChatLength", "chatPosition",
                 "parallaxFix", "crosshairPerspective", "extendChatBackground"
             ).forEach(property -> hidePropertyIf(property, minecraft112));
+
+            hidePropertyIf("KeyboardLayout", () -> !SystemUtils.IS_OS_LINUX);
         } catch (Exception e) {
             Patcher.instance.getLogger().error("Failed to access property.", e);
         }

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -77,7 +77,7 @@ public class PatcherConfig extends Vigilant {
         category = "Bug Fixes", subcategory = "Linux",
         options = {"QWERTY", "AZERTY"}
     )
-    public static int KeyboardLayout = 0;
+    public static int keyboardLayout = 0;
 
 
     // MISCELLANEOUS
@@ -1326,7 +1326,7 @@ public class PatcherConfig extends Vigilant {
                 "parallaxFix", "crosshairPerspective", "extendChatBackground"
             ).forEach(property -> hidePropertyIf(property, minecraft112));
 
-            hidePropertyIf("KeyboardLayout", () -> !SystemUtils.IS_OS_LINUX);
+            hidePropertyIf("keyboardLayout", () -> !SystemUtils.IS_OS_LINUX);
         } catch (Exception e) {
             Patcher.instance.getLogger().error("Failed to access property.", e);
         }

--- a/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
+++ b/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
@@ -2,17 +2,19 @@ package club.sk1er.patcher.util.keybind.linux;
 
 import club.sk1er.patcher.config.PatcherConfig;
 import net.minecraft.client.Minecraft;
-import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
-import net.minecraftforge.fml.common.gameevent.InputEvent;
+import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.inventory.GuiContainer;
 import net.minecraft.inventory.Slot;
+import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
+import net.minecraftforge.fml.common.gameevent.InputEvent;
+import net.minecraftforge.client.event.GuiScreenEvent;
 import org.apache.commons.lang3.SystemUtils;
 import org.lwjgl.input.Keyboard;
 
 import java.util.HashMap;
 
-//#if MC==10809
-import net.minecraftforge.client.event.GuiScreenEvent;
+//#if MC==11202
+//$$ import net.minecraft.inventory.ClickType;
 //#endif
 
 public class LinuxKeybindFix {
@@ -54,25 +56,32 @@ public class LinuxKeybindFix {
         }
     }
 
-    //#if MC==10809
     @SubscribeEvent
     public void onGuiPress(GuiScreenEvent.KeyboardInputEvent.Pre event) {
-        if (SystemUtils.IS_OS_LINUX && PatcherConfig.KeyboardLayout == 1 && event.gui instanceof GuiContainer && mc.thePlayer != null
+        //#if MC==10809
+        GuiScreen guiScreen = event.gui;
+        //#else
+        //$$ GuiScreen guiScreen = event.getGui();
+        //#endif
+        if (SystemUtils.IS_OS_LINUX && PatcherConfig.KeyboardLayout == 1 && guiScreen instanceof GuiContainer && mc.thePlayer != null
             && Keyboard.isCreated() && Keyboard.getEventKeyState()) {
             char charPressed = Keyboard.getEventCharacter();
-            GuiContainer gui = (GuiContainer) event.gui;
+            GuiContainer gui = (GuiContainer) guiScreen;
             Slot slot = gui.getSlotUnderMouse();
             if (slot != null && azertyTriggers.containsKey(charPressed)) {
                 mc.playerController.windowClick(
                     gui.inventorySlots.windowId,
                     slot.slotNumber,
                     azertyTriggers.get(charPressed),
+                    //#if MC==10809
                     2,
-                    event.gui.mc.thePlayer
+                    //#else
+                    //$$ ClickType.SWAP,
+                    //#endif
+                    mc.thePlayer
                 );
                 event.setCanceled(true);
             }
         }
     }
-//#endif
 }

--- a/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
+++ b/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
@@ -35,7 +35,7 @@ public class LinuxKeybindFix {
     @SubscribeEvent
     public void onKeyPress(InputEvent.KeyInputEvent event) {
         if (SystemUtils.IS_OS_LINUX && mc.thePlayer != null && Keyboard.isCreated() && Keyboard.getEventKeyState()) {
-            if (PatcherConfig.KeyboardLayout == 0) {
+            if (PatcherConfig.keyboardLayout == 0) {
                 final int eventKey = Keyboard.getEventKey();
                 switch (eventKey) {
                     case 145:
@@ -63,7 +63,7 @@ public class LinuxKeybindFix {
         //#else
         //$$ GuiScreen guiScreen = event.getGui();
         //#endif
-        if (SystemUtils.IS_OS_LINUX && PatcherConfig.KeyboardLayout == 1 && guiScreen instanceof GuiContainer && mc.thePlayer != null
+        if (SystemUtils.IS_OS_LINUX && PatcherConfig.keyboardLayout == 1 && guiScreen instanceof GuiContainer && mc.thePlayer != null
             && Keyboard.isCreated() && Keyboard.getEventKeyState()) {
             char charPressed = Keyboard.getEventCharacter();
             GuiContainer gui = (GuiContainer) guiScreen;

--- a/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
+++ b/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
@@ -9,19 +9,58 @@ import org.lwjgl.input.Keyboard;
 public class LinuxKeybindFix {
 
     private final Minecraft mc = Minecraft.getMinecraft();
+    private static final HashMap<Character, Integer> azertyTriggers = new HashMap<Character, Integer>() {{
+        put('&', 0);
+        put('é', 1);
+        put('"', 2);
+        put('\'', 3);
+        put('(', 4);
+        put('§', 5);
+        put('è', 6);
+        put('!', 7);
+        put('ç', 8);
+    }};
 
     @SubscribeEvent
     public void onKeyPress(InputEvent.KeyInputEvent event) {
         if (SystemUtils.IS_OS_LINUX && mc.thePlayer != null && Keyboard.isCreated() && Keyboard.getEventKeyState()) {
-            final int eventKey = Keyboard.getEventKey();
-            switch (eventKey) {
-                case 145:
-                    if (mc.gameSettings.keyBindsHotbar[1].getKeyCode() == 3) mc.thePlayer.inventory.currentItem = 1;
-                    break;
+            if (PatcherConfig.KeyboardLayout == 0) {
+                final int eventKey = Keyboard.getEventKey();
+                switch (eventKey) {
+                    case 145:
+                        if (mc.gameSettings.keyBindsHotbar[1].getKeyCode() == 3) mc.thePlayer.inventory.currentItem = 1;
+                        break;
 
-                case 144:
-                    if (mc.gameSettings.keyBindsHotbar[5].getKeyCode() == 7) mc.thePlayer.inventory.currentItem = 5;
-                    break;
+                    case 144:
+                        if (mc.gameSettings.keyBindsHotbar[5].getKeyCode() == 7) mc.thePlayer.inventory.currentItem = 5;
+                        break;
+                }
+            } else {
+                char charPressed = Keyboard.getEventCharacter();
+                if (triggers.containsKey(charPressed)) {
+                    int i = triggers.get(charPressed);
+                    if (mc.gameSettings.keyBindsHotbar[i].getKeyCode() == i + 2) mc.thePlayer.inventory.currentItem = i;
+                }
+            }
+        }
+    }
+
+    @SubscribeEvent
+    public void onGuiPress(GuiScreenEvent.KeyboardInputEvent.Pre event) {
+        if (PatcherConfig.KeyboardLayout == 1 && event.gui instanceof GuiContainer && mc.thePlayer != null && Keyboard.isCreated()
+            && Keyboard.getEventKeyState()) {
+            char charPressed = Keyboard.getEventCharacter();
+            GuiContainer gui = (GuiContainer) event.gui;
+            Slot slot = gui.getSlotUnderMouse();
+            if (slot != null && triggers.containsKey(charPressed)) {
+                mc.playerController.windowClick(
+                    gui.inventorySlots.windowId,
+                    slot.slotNumber,
+                    triggers.get(charPressed),
+                    2,
+                    event.gui.mc.thePlayer
+                );
+                event.setCanceled(true);
             }
         }
     }

--- a/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
+++ b/src/main/java/club/sk1er/patcher/util/keybind/linux/LinuxKeybindFix.java
@@ -1,10 +1,19 @@
 package club.sk1er.patcher.util.keybind.linux;
 
+import club.sk1er.patcher.config.PatcherConfig;
 import net.minecraft.client.Minecraft;
 import net.minecraftforge.fml.common.eventhandler.SubscribeEvent;
 import net.minecraftforge.fml.common.gameevent.InputEvent;
+import net.minecraft.client.gui.inventory.GuiContainer;
+import net.minecraft.inventory.Slot;
 import org.apache.commons.lang3.SystemUtils;
 import org.lwjgl.input.Keyboard;
+
+import java.util.HashMap;
+
+//#if MC==10809
+import net.minecraftforge.client.event.GuiScreenEvent;
+//#endif
 
 public class LinuxKeybindFix {
 
@@ -37,26 +46,27 @@ public class LinuxKeybindFix {
                 }
             } else {
                 char charPressed = Keyboard.getEventCharacter();
-                if (triggers.containsKey(charPressed)) {
-                    int i = triggers.get(charPressed);
+                if (azertyTriggers.containsKey(charPressed)) {
+                    int i = azertyTriggers.get(charPressed);
                     if (mc.gameSettings.keyBindsHotbar[i].getKeyCode() == i + 2) mc.thePlayer.inventory.currentItem = i;
                 }
             }
         }
     }
 
+    //#if MC==10809
     @SubscribeEvent
     public void onGuiPress(GuiScreenEvent.KeyboardInputEvent.Pre event) {
-        if (PatcherConfig.KeyboardLayout == 1 && event.gui instanceof GuiContainer && mc.thePlayer != null && Keyboard.isCreated()
-            && Keyboard.getEventKeyState()) {
+        if (SystemUtils.IS_OS_LINUX && PatcherConfig.KeyboardLayout == 1 && event.gui instanceof GuiContainer && mc.thePlayer != null
+            && Keyboard.isCreated() && Keyboard.getEventKeyState()) {
             char charPressed = Keyboard.getEventCharacter();
             GuiContainer gui = (GuiContainer) event.gui;
             Slot slot = gui.getSlotUnderMouse();
-            if (slot != null && triggers.containsKey(charPressed)) {
+            if (slot != null && azertyTriggers.containsKey(charPressed)) {
                 mc.playerController.windowClick(
                     gui.inventorySlots.windowId,
                     slot.slotNumber,
-                    triggers.get(charPressed),
+                    azertyTriggers.get(charPressed),
                     2,
                     event.gui.mc.thePlayer
                 );
@@ -64,4 +74,5 @@ public class LinuxKeybindFix {
             }
         }
     }
+//#endif
 }


### PR DESCRIPTION
This is needed since in azerty the number keys are only activated when holding shift and if you bind them to the normal ones (& for 1) you have the problem that it doesn't work when you press shift and it doesn't work for quick swapping inside the inventory. This PR fixes both of those issues.
I had to add a separate config option that only shows on Linux since I couldn't find a good way to detect the keyboard layout. 