### PR TITLE
actions: cache the loom-cache folder

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,6 +32,7 @@ jobs:
           path: |
             ~/.gradle/caches
             ~/.gradle/wrapper
+            **/loom-cache
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
           restore-keys: |
             ${{ runner.os }}-gradle-


### PR DESCRIPTION
This significantly improves the performance of builds on actions as it ensures loom cache data is stored in the actions cache. This avoids loom thinking that ATs are dirty and recreating the Minecraft artifacts every build.