### PR TITLE
fix: add null check to getting a `ChatLine`'s ID in `GuiNewChat#deleteChatLine`

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiNewChatMixin_NullChatLineFix.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiNewChatMixin_NullChatLineFix.java
@@ -1,0 +1,16 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+import net.minecraft.client.gui.ChatLine;
+import net.minecraft.client.gui.GuiNewChat;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(GuiNewChat.class)
+public class GuiNewChatMixin_NullChatLineFix {
+    @Redirect(method = "deleteChatLine", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/ChatLine;getChatLineID()I"))
+    private int patcher$checkIfChatLineIsNull(ChatLine instance) {
+        if (instance == null) return -1;
+        return instance.getChatLineID();
+    }
+}

--- a/src/main/resources/patcher.mixins.json
+++ b/src/main/resources/patcher.mixins.json
@@ -48,6 +48,7 @@
     "bugfixes.GuiIngameMixin_ScoreboardTextTransparency",
     "bugfixes.GuiLanguageMixin_ResetUnicodeFont",
     "bugfixes.GuiNewChatMixin_ChatComponentBoundary",
+    "bugfixes.GuiNewChatMixin_NullChatLineFix",
     "bugfixes.GuiOptionsMixin_SaveSettings",
     "bugfixes.GuiScreenBookMixin_ResolveRenderLayer",
     "bugfixes.GuiScreenMixin_FixWindowsIME",


### PR DESCRIPTION
Previously, `GuiNewChat` would not check if the `ChatLine` was null before getting its ID when deleting it in `deleteChatLine`. This PR makes `ChatLine#getChatLineID` return `-1` if the `ChatLine` instance is null when called from `deleteChatLine`. 

This issue mainly occurred when sending a chat message while joining a world from my testing, and this PR fixes #73.