### PR TITLE
BugFix: 1.8.9 Sneak Glitch

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **Player Void Rendering** - Resolve the black box around the player while in the void. *default
 - **Alex Arm Position** - Resolve Alex-model arms being shifted down further than Steve-model arms. *default
 - **Resource Exploit Fix** - Resolve an exploit in 1.8 allowing servers to look through directories. *default
+- **Sneak Fix** - Resolve faulty crouch ground collision detection seemingly dropping you off the edge of blocks. *default
 </details>
 <details>
   <summary>Experimental</summary>

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityMixin_SneakFix.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityMixin_SneakFix.java
@@ -1,0 +1,35 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+import net.minecraft.entity.Entity;
+import net.minecraft.util.AxisAlignedBB;
+import net.minecraft.world.World;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Redirect;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin_SneakFix {
+    @Shadow
+    public boolean onGround;
+
+    @Shadow
+    public World worldObj;
+
+    @Shadow
+    public abstract AxisAlignedBB getEntityBoundingBox();
+
+    @Redirect(
+        method = "moveEntity",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/entity/Entity;onGround:Z",
+            opcode = Opcodes.GETFIELD,
+            ordinal = 0
+        )
+    )
+    private boolean patcher$overrideOnGround(Entity instance) {
+        return !this.worldObj.getCollidingBoundingBoxes((Entity) (Object) this, this.getEntityBoundingBox().offset(0, -1.0, 0)).isEmpty();
+    }
+}

--- a/src/main/resources/patcher.mixins.json
+++ b/src/main/resources/patcher.mixins.json
@@ -36,6 +36,7 @@
     "bugfixes.ContainerMixin_PlaySound",
     "bugfixes.EntityLivingBaseMixin_MouseDelayFix",
     "bugfixes.EntityMixin_FixedBrightness",
+    "bugfixes.EntityMixin_SneakFix",
     "bugfixes.EntityMixin_SprintParticles",
     "bugfixes.EntityRendererMixin_PolygonOffset",
     "bugfixes.EntityXPOrbMixin_AdjustHeight",

--- a/versions/1.12.2-1.8.9.txt
+++ b/versions/1.12.2-1.8.9.txt
@@ -13,10 +13,12 @@ net.minecraft.server.MinecraftServer applyServerIconToResponse() net.minecraft.s
 net.minecraft.client.renderer.chunk.VisGraph floodFill() net.minecraft.client.renderer.chunk.VisGraph func_178604_a()
 net.minecraft.client.renderer.chunk.VisGraph addEdges() net.minecraft.client.renderer.chunk.VisGraph func_178610_a()
 net.minecraft.client.particle.ParticleManager tickParticleList() net.minecraft.client.particle.EffectRenderer updateEffectAlphaLayer()
+net.minecraft.entity.Entity move() moveEntity()
 
 net.minecraft.init.MobEffects POISON net.minecraft.potion.Potion poison
 net.minecraft.init.MobEffects WITHER net.minecraft.potion.Potion wither
 net.minecraft.client.gui.GuiScreenServerList lastScreen net.minecraft.client.gui.GuiScreenServerList field_146303_a
+net.minecraft.entity.Entity world worldObj
 
 net.minecraft.init.MobEffects net.minecraft.potion.Potion
 net.minecraft.util.BlockRenderLayer net/minecraft/util/EnumWorldBlockLayer


### PR DESCRIPTION
This fixes a bug in 1.8.9/1.12.2 that causes the game to stop all momentum before dropping the player off a block if they sneak at the right time.
If you take a look at the source code for sneak collision, it checks if the player is on the ground by calling the onGround field. The issue is, onGround is updated _after_ sneak collisions are determined. This means that sneaking within one tick after leaving a block will cause the sneak collision code to stop displacement/reset momentum to prevent you from falling off a block. This is seen as sudden jolt, followed by a fall rather than a smooth fall because the crouch did not connect.
I was unable to find a Mojang bug report for this issue but it was fixed in later versions. It is very possible that there was a bug report that I missed.