### PR TITLE
New: Fix bad sneak ground collision detection in 1.8.9 and 1.12.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - **Player Void Rendering** - Resolve the black box around the player while in the void. *default
 - **Alex Arm Position** - Resolve Alex-model arms being shifted down further than Steve-model arms. *default
 - **Resource Exploit Fix** - Resolve an exploit in 1.8 allowing servers to look through directories. *default
+- **Sneak Fix** - Resolve faulty sneak ground collision detection seemingly dropping you off the edge of blocks. *default
 </details>
 <details>
   <summary>Experimental</summary>

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityMixin_SneakFix.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityMixin_SneakFix.java
@@ -1,0 +1,44 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+//#if MC==11202
+//$$ import net.minecraft.entity.MoverType;
+//#endif
+import net.minecraft.entity.Entity;
+import net.minecraft.entity.player.EntityPlayer;
+import org.objectweb.asm.Opcodes;
+import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.Redirect;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+@Mixin(Entity.class)
+public abstract class EntityMixin_SneakFix {
+    private double yDisplacement;
+
+    @Inject(method = "moveEntity", at = @At(value = "HEAD"))
+    private void moveEntity(
+        //#if MC==11202
+        //$$ MoverType type,
+        //#endif
+        double x, double y, double z, CallbackInfo ci) {
+        this.yDisplacement = y;
+    }
+
+    @Redirect(
+        method = "moveEntity",
+        at = @At(
+            value = "FIELD",
+            target = "Lnet/minecraft/entity/Entity;onGround:Z",
+            opcode = Opcodes.GETFIELD,
+            ordinal = 0
+        )
+    )
+    private boolean patcher$overrideOnGround(Entity entity) {
+        return entity instanceof EntityPlayer
+            && !((EntityPlayer) entity).capabilities.isFlying
+            && yDisplacement <= 0.0D
+            && entity.fallDistance < entity.stepHeight
+            && !entity.worldObj.getCollidingBoundingBoxes(entity, entity.getEntityBoundingBox().offset(0, -entity.stepHeight, 0)).isEmpty();
+    }
+}

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityMixin_SneakFix.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/EntityMixin_SneakFix.java
@@ -8,23 +8,10 @@ import net.minecraft.entity.player.EntityPlayer;
 import org.objectweb.asm.Opcodes;
 import org.spongepowered.asm.mixin.Mixin;
 import org.spongepowered.asm.mixin.injection.At;
-import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.Redirect;
-import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
 @Mixin(Entity.class)
 public abstract class EntityMixin_SneakFix {
-    private double yDisplacement;
-
-    @Inject(method = "moveEntity", at = @At(value = "HEAD"))
-    private void moveEntity(
-        //#if MC==11202
-        //$$ MoverType type,
-        //#endif
-        double x, double y, double z, CallbackInfo ci) {
-        this.yDisplacement = y;
-    }
-
     @Redirect(
         method = "moveEntity",
         at = @At(
@@ -34,11 +21,15 @@ public abstract class EntityMixin_SneakFix {
             ordinal = 0
         )
     )
-    private boolean patcher$overrideOnGround(Entity entity) {
+    private boolean patcher$overrideOnGround(Entity entity,
+                                             //#if MC==11202
+                                             //$$ MoverType type,
+                                             //#endif
+                                             double xDisplacement, double yDisplacement) {
         return entity instanceof EntityPlayer
             && !((EntityPlayer) entity).capabilities.isFlying
             && yDisplacement <= 0.0D
             && entity.fallDistance < entity.stepHeight
-            && !entity.worldObj.getCollidingBoundingBoxes(entity, entity.getEntityBoundingBox().offset(0, -entity.stepHeight, 0)).isEmpty();
+            && !entity.worldObj.getCollidingBoundingBoxes(entity, entity.getEntityBoundingBox().offset(0, entity.fallDistance - entity.stepHeight, 0)).isEmpty();
     }
 }

--- a/src/main/resources/patcher.mixins.json
+++ b/src/main/resources/patcher.mixins.json
@@ -36,6 +36,7 @@
     "bugfixes.ContainerMixin_PlaySound",
     "bugfixes.EntityLivingBaseMixin_MouseDelayFix",
     "bugfixes.EntityMixin_FixedBrightness",
+    "bugfixes.EntityMixin_SneakFix",
     "bugfixes.EntityMixin_SprintParticles",
     "bugfixes.EntityRendererMixin_PolygonOffset",
     "bugfixes.EntityXPOrbMixin_AdjustHeight",

--- a/versions/1.12.2-1.8.9.txt
+++ b/versions/1.12.2-1.8.9.txt
@@ -13,6 +13,7 @@ net.minecraft.server.MinecraftServer applyServerIconToResponse() net.minecraft.s
 net.minecraft.client.renderer.chunk.VisGraph floodFill() net.minecraft.client.renderer.chunk.VisGraph func_178604_a()
 net.minecraft.client.renderer.chunk.VisGraph addEdges() net.minecraft.client.renderer.chunk.VisGraph func_178610_a()
 net.minecraft.client.particle.ParticleManager tickParticleList() net.minecraft.client.particle.EffectRenderer updateEffectAlphaLayer()
+net.minecraft.entity.Entity move() moveEntity()
 
 net.minecraft.init.MobEffects POISON net.minecraft.potion.Potion poison
 net.minecraft.init.MobEffects WITHER net.minecraft.potion.Potion wither


### PR DESCRIPTION
This fixes a bug in 1.8.9/1.12.2 that causes the game to stop all momentum before dropping the player off a block if they sneak at the right time.
If you take a look at the source code for sneak collision, it checks if the player is on the ground by calling the onGround field. The issue is, onGround is updated _after_ sneak collisions are determined. This means that sneaking within one tick after leaving a block will cause the sneak collision code to stop displacement/reset momentum to prevent you from falling off a block. This is seen as sudden jolt, followed by a fall rather than a smooth fall because the crouch did not connect.
I was unable to find a Mojang bug report for this issue but it was fixed in later versions. It is very possible that there was a bug report that I missed. My implementation is very similar to current 1.19.1 sneak collision detection.