### PR TITLE
new: add support for og:image/twitter:image meta tags and img tags for image preview

### DIFF
--- a/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
+++ b/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
@@ -160,28 +160,28 @@ public class ImagePreview {
             connection.setConnectTimeout(15000);
             connection.setDoOutput(true);
 
-            if (connection.getHeaderField("Content-Type").contains("text/html")) {
-                String body = IOUtils.toString(connection.getInputStream());
-                String imageURL = "";
-                Matcher matcher;
-                if ((matcher = OGP_IMAGE_REGEX.matcher(body)).find()) {
-                    imageURL = matcher.group("url");
-                } else if ((matcher = IMG_TAG_REGEX.matcher(body)).find()) {
-                    imageURL = matcher.group("url");
-                }
-                if (imageURL.startsWith("/")) {
-                    URL urlObj = new URL(url);
-                    imageURL = urlObj.getProtocol() + "://" + urlObj.getHost() + imageURL;
-                }
-
-                if (!imageURL.isEmpty()) {
-                    loadUrl(imageURL);
-                    connection.disconnect();
-                    return;
-                }
-            }
-
             try (InputStream stream = connection.getInputStream()) {
+                if (connection.getHeaderField("Content-Type").contains("text/html")) {
+                    String body = IOUtils.toString(stream);
+                    String imageURL = "";
+                    Matcher matcher;
+                    if ((matcher = OGP_IMAGE_REGEX.matcher(body)).find()) {
+                        imageURL = matcher.group("url");
+                    } else if ((matcher = IMG_TAG_REGEX.matcher(body)).find()) {
+                        imageURL = matcher.group("url");
+                    }
+                    if (imageURL.startsWith("/")) {
+                        URL urlObj = new URL(url);
+                        imageURL = urlObj.getProtocol() + "://" + urlObj.getHost() + imageURL;
+                    }
+
+                    if (!imageURL.isEmpty()) {
+                        loadUrl(imageURL);
+                        connection.disconnect();
+                        return;
+                    }
+                }
+
                 image = TextureUtil.readBufferedImage(stream);
             }
         } catch (Exception e) {

--- a/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
+++ b/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
@@ -5,13 +5,6 @@ import club.sk1er.patcher.config.PatcherConfig;
 import gg.essential.api.EssentialAPI;
 import gg.essential.api.utils.Multithreading;
 import gg.essential.api.utils.TrustedHostsUtil;
-import java.awt.image.BufferedImage;
-import java.io.InputStream;
-import java.net.HttpURLConnection;
-import java.net.MalformedURLException;
-import java.net.URL;
-import java.util.regex.Matcher;
-import java.util.regex.Pattern;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.ScaledResolution;
 import net.minecraft.client.renderer.GlStateManager;
@@ -30,14 +23,17 @@ import org.lwjgl.input.Keyboard;
 import org.lwjgl.input.Mouse;
 import org.lwjgl.opengl.GL11;
 
-public class ImagePreview {
+import java.awt.image.BufferedImage;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.MalformedURLException;
+import java.net.URL;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
-    private final Pattern OGP_IMAGE_REGEX = Pattern.compile(
-        "<meta property=\"(?:og:image|twitter:image)\" content=\"(?<url>.+?)\".*?/?>"
-    );
-    private final Pattern IMG_TAG_REGEX = Pattern.compile(
-        "<img.*?src=\"(?<url>.+?)\".*?>"
-    );
+public class ImagePreview {
+    private final Pattern OGP_IMAGE_REGEX = Pattern.compile("<meta property=\"(?:og:image|twitter:image)\" content=\"(?<url>.+?)\".*?/?>");
+    private final Pattern IMG_TAG_REGEX = Pattern.compile("<img.*?src=\"(?<url>.+?)\".*?>");
 
     private final Minecraft mc = Minecraft.getMinecraft();
     private BufferedImage image;
@@ -49,19 +45,12 @@ public class ImagePreview {
 
     @SubscribeEvent
     public void renderTickEvent(TickEvent.RenderTickEvent event) {
-        if (
-            event.phase != TickEvent.Phase.END || !PatcherConfig.imagePreview
-        ) return;
-        final IChatComponent chatComponent = mc.ingameGUI
-            .getChatGUI()
-            .getChatComponent(Mouse.getX(), Mouse.getY());
+        if (event.phase != TickEvent.Phase.END || !PatcherConfig.imagePreview) return;
+        final IChatComponent chatComponent = mc.ingameGUI.getChatGUI().getChatComponent(Mouse.getX(), Mouse.getY());
         if (chatComponent != null) {
             final ChatStyle chatStyle = chatComponent.getChatStyle();
             final ClickEvent chatClickEvent = chatStyle.getChatClickEvent();
-            if (
-                chatStyle.getChatClickEvent() != null &&
-                chatClickEvent.getAction() == ClickEvent.Action.OPEN_URL
-            ) {
+            if (chatStyle.getChatClickEvent() != null && chatClickEvent.getAction() == ClickEvent.Action.OPEN_URL) {
                 handle(chatClickEvent.getValue());
             }
         }
@@ -73,9 +62,7 @@ public class ImagePreview {
             final String host = url.getHost();
             boolean found = false;
 
-            for (TrustedHostsUtil.TrustedHost trustedHost : EssentialAPI
-                .getTrustedHostsUtil()
-                .getTrustedHosts()) {
+            for (TrustedHostsUtil.TrustedHost trustedHost : EssentialAPI.getTrustedHostsUtil().getTrustedHosts()) {
                 for (String domain : trustedHost.getDomains()) {
                     if (host.equalsIgnoreCase(domain)) {
                         found = true;
@@ -97,11 +84,7 @@ public class ImagePreview {
 
         if (value.contains("imgur.com/")) {
             final String[] split = value.split("/");
-            value =
-                String.format(
-                    "https://i.imgur.com/%s.png",
-                    split[split.length - 1]
-                );
+            value = String.format("https://i.imgur.com/%s.png", split[split.length - 1]);
         }
 
         if (!value.equals(loaded)) {
@@ -116,11 +99,7 @@ public class ImagePreview {
 
         if (this.image != null) {
             final DynamicTexture dynamicTexture = new DynamicTexture(image);
-            GL11.glTexParameteri(
-                GL11.GL_TEXTURE_2D,
-                GL11.GL_TEXTURE_MAG_FILTER,
-                GL11.GL_NEAREST
-            );
+            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
             dynamicTexture.updateDynamicTexture();
             this.tex = dynamicTexture.getGlTextureId();
             this.width = image.getWidth();
@@ -140,10 +119,8 @@ public class ImagePreview {
             float aspectRatio = width / (float) height;
             float scaleWidth = scaledResolution.getScaledWidth() * scaleFactor;
 
-            if (!Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) scaleWidth *=
-                PatcherConfig.imagePreviewWidth;
-            if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) scaleWidth =
-                this.width;
+            if (!Keyboard.isKeyDown(Keyboard.KEY_LSHIFT)) scaleWidth *= PatcherConfig.imagePreviewWidth;
+            if (Keyboard.isKeyDown(Keyboard.KEY_LCONTROL)) scaleWidth = this.width;
 
             float maxWidth = scaleWidth;
             float height = maxWidth / aspectRatio;
@@ -153,11 +130,7 @@ public class ImagePreview {
                 maxWidth = height * aspectRatio;
             }
 
-            GL11.glTexParameteri(
-                GL11.GL_TEXTURE_2D,
-                GL11.GL_TEXTURE_MAG_FILTER,
-                GL11.GL_NEAREST
-            );
+            GL11.glTexParameteri(GL11.GL_TEXTURE_2D, GL11.GL_TEXTURE_MAG_FILTER, GL11.GL_NEAREST);
             drawTexturedModalRect(0, 0, (int) maxWidth, (int) height);
             GlStateManager.popMatrix();
         }
@@ -166,30 +139,11 @@ public class ImagePreview {
     public void drawTexturedModalRect(int x, int y, int width, int height) {
         Tessellator tessellator = Tessellator.getInstance();
         WorldRenderer worldrenderer = tessellator.getWorldRenderer();
-        worldrenderer.begin(
-            GL11.GL_QUADS,
-            DefaultVertexFormats.POSITION_TEX_COLOR
-        );
-        worldrenderer
-            .pos(x, y + height, 0)
-            .tex(0, 1)
-            .color(255, 255, 255, 255)
-            .endVertex();
-        worldrenderer
-            .pos(x + width, y + height, 0)
-            .tex(1, 1)
-            .color(255, 255, 255, 255)
-            .endVertex();
-        worldrenderer
-            .pos(x + width, y, 0)
-            .tex(1, 0)
-            .color(255, 255, 255, 255)
-            .endVertex();
-        worldrenderer
-            .pos(x, y, 0)
-            .tex(0, 0)
-            .color(255, 255, 255, 255)
-            .endVertex();
+        worldrenderer.begin(GL11.GL_QUADS, DefaultVertexFormats.POSITION_TEX_COLOR);
+        worldrenderer.pos(x, y + height, 0).tex(0, 1).color(255, 255, 255, 255).endVertex();
+        worldrenderer.pos(x + width, y + height, 0).tex(1, 1).color(255, 255, 255, 255).endVertex();
+        worldrenderer.pos(x + width, y, 0).tex(1, 0).color(255, 255, 255, 255).endVertex();
+        worldrenderer.pos(x, y, 0).tex(0, 0).color(255, 255, 255, 255).endVertex();
         tessellator.draw();
     }
 
@@ -201,17 +155,12 @@ public class ImagePreview {
             connection.setRequestMethod("GET");
             connection.setUseCaches(true);
             connection.setInstanceFollowRedirects(true);
-            connection.addRequestProperty(
-                "User-Agent",
-                "Patcher Image Previewer"
-            );
+            connection.addRequestProperty("User-Agent", "Patcher Image Previewer");
             connection.setReadTimeout(15000);
             connection.setConnectTimeout(15000);
             connection.setDoOutput(true);
 
-            if (
-                connection.getHeaderField("Content-Type").contains("text/html")
-            ) {
+            if (connection.getHeaderField("Content-Type").contains("text/html")) {
                 String body = IOUtils.toString(connection.getInputStream());
                 String imageURL = "";
                 Matcher matcher;
@@ -222,11 +171,7 @@ public class ImagePreview {
                 }
                 if (imageURL.startsWith("/")) {
                     URL urlObj = new URL(url);
-                    imageURL =
-                        urlObj.getProtocol() +
-                        "://" +
-                        urlObj.getHost() +
-                        imageURL;
+                    imageURL = urlObj.getProtocol() + "://" + urlObj.getHost() + imageURL;
                 }
 
                 if (!imageURL.isEmpty()) {
@@ -240,9 +185,7 @@ public class ImagePreview {
                 image = TextureUtil.readBufferedImage(stream);
             }
         } catch (Exception e) {
-            Patcher.instance
-                .getLogger()
-                .error("Failed to load an image preview from {}", url, e);
+            Patcher.instance.getLogger().error("Failed to load an image preview from {}", url, e);
         } finally {
             if (connection != null) connection.disconnect();
         }


### PR DESCRIPTION
Resolves Essential's image links not previewing, allows many other sources to be previewed

![](https://imagedelivery.net/aG82t-qDLn415HP9HHoOeg/8f9771d0-96a4-4b97-bfec-09d119714000/original)
![](https://imagedelivery.net/aG82t-qDLn415HP9HHoOeg/7a3feed7-30af-4ba2-2e9b-508661c83c00/original)