### PR TITLE
extend the case command fix to tabcompletion options

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/CommandHandlerMixin_CaseCommands.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/CommandHandlerMixin_CaseCommands.java
@@ -9,7 +9,7 @@ import java.util.Locale;
 
 @Mixin(CommandHandler.class)
 public class CommandHandlerMixin_CaseCommands {
-    @ModifyArg(method = "executeCommand", at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
+    @ModifyArg(method = {"executeCommand", "getTabCompletionOptions"}, at = @At(value = "INVOKE", target = "Ljava/util/Map;get(Ljava/lang/Object;)Ljava/lang/Object;", remap = false))
     private Object patcher$makeLowerCaseForGet(Object s) {
         if (s instanceof String) {
             return ((String) s).toLowerCase(Locale.ENGLISH);
@@ -24,4 +24,10 @@ public class CommandHandlerMixin_CaseCommands {
         }
         return s;
     }
+
+    @ModifyArg(method = "getTabCompletionOptions", at = @At(value = "INVOKE", target = "Lnet/minecraft/command/CommandBase;doesStringStartWith(Ljava/lang/String;Ljava/lang/String;)Z"), index = 0)
+    private String patcher$makeLowerCaseForTabComplete(String s) {
+        return s != null ? s.toLowerCase(Locale.ENGLISH) : null;
+    }
+
 }


### PR DESCRIPTION
this way you can use the tab completion options of a command even when you type the command with any case