### PR TITLE
Prevents the actionbar text from rendering above the armor/health bar.

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -72,6 +72,13 @@ public class PatcherConfig extends Vigilant {
     public static boolean fixedAlexArms = true;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Fix Actionbar Overlap",
+        description = "Prevents the actionbar text from rendering above the armor/health bar.",
+        category = "Bug Fixes", subcategory = "Rendering"
+    )
+    public static boolean fixActionbarOverlap;
+
+    @Property(
         type = PropertyType.SELECTOR, name = "Keyboard Layout",
         description = "The layout of your keyboard, used to fix input bugs accordingly.",
         category = "Bug Fixes", subcategory = "Linux",

--- a/src/main/java/club/sk1er/patcher/mixins/features/GuiIngameForgeMixin_ActionbarText.java
+++ b/src/main/java/club/sk1er/patcher/mixins/features/GuiIngameForgeMixin_ActionbarText.java
@@ -1,19 +1,38 @@
 package club.sk1er.patcher.mixins.features;
 
+import club.sk1er.patcher.config.PatcherConfig;
 import club.sk1er.patcher.hooks.GuiIngameForgeHook;
 import net.minecraft.client.gui.FontRenderer;
 import net.minecraftforge.client.GuiIngameForge;
 import org.spongepowered.asm.mixin.Mixin;
+import org.spongepowered.asm.mixin.Shadow;
 import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.ModifyArg;
 import org.spongepowered.asm.mixin.injection.Redirect;
 
 @Mixin(GuiIngameForge.class)
 public class GuiIngameForgeMixin_ActionbarText {
+
+    @Shadow(remap = false)
+    public static int left_height;
+
     @Redirect(
         method = "renderRecordOverlay",
-        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I")
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/gui/FontRenderer;drawString(Ljava/lang/String;III)I"),
+        remap = false
     )
     private int patcher$drawCustomActionbarText(FontRenderer instance, String text, int x, int y, int color) {
         return GuiIngameForgeHook.drawActionbarText(text, color);
     }
+
+    @ModifyArg(
+        method = "renderRecordOverlay",
+        at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;translate(FFF)V"),
+        index = 1,
+        remap = false
+    )
+    private float patcher$fixOverlappingActionbarText(float y) {
+        return PatcherConfig.fixActionbarOverlap && 68 < left_height ? y + 68f - left_height : y;
+    }
+
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/57050655/196226394-a4ab1a91-772d-4f90-aa76-708c2eae1286.png)

![image](https://user-images.githubusercontent.com/57050655/196226460-e02ef829-c059-44e9-b520-5b67f7717747.png)
