### PR TITLE
Fix resource pack folder sometimes not opening on windows

### DIFF
--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
@@ -18,8 +18,10 @@ public class GuiScreenResourcePacksMixin_FixOpenPackFolder {
             value = "INVOKE",
             target = "Lnet/minecraft/client/resources/ResourcePackRepository;getDirResourcepacks()Ljava/io/File;",
             shift = At.Shift.BY,
-            by = 2),
-        cancellable = true)
+            by = 2
+        ),
+        cancellable = true
+    )
     private void patcher$fixFolderOpening(CallbackInfo ci) {
         if (UDesktop.open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks())) {
             ci.cancel();

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
@@ -17,8 +17,7 @@ public class GuiScreenResourcePacksMixin_FixOpenPackFolder {
         @At(
             value = "INVOKE",
             target = "Lnet/minecraft/client/resources/ResourcePackRepository;getDirResourcepacks()Ljava/io/File;",
-            shift = At.Shift.BY,
-            by = 2
+            shift = At.Shift.AFTER
         ),
         cancellable = true
     )

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
@@ -1,5 +1,6 @@
 package club.sk1er.patcher.mixins.bugfixes;
 
+import gg.essential.universal.UDesktop;
 import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreenResourcePacks;
 import org.spongepowered.asm.mixin.Mixin;
@@ -7,51 +8,22 @@ import org.spongepowered.asm.mixin.injection.At;
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
 
-import java.awt.Desktop;
-
-//#if MC==10809
-import java.io.IOException;
-//#endif
-
-//#if MC==11202
-//$$ import net.minecraft.util.Util;
-//#endif
-
 @Mixin(GuiScreenResourcePacks.class)
 public class GuiScreenResourcePacksMixin_FixOpenPackFolder {
-    //#if MC==10809
+
     @Inject(
         method = "actionPerformed",
         at =
         @At(
             value = "INVOKE",
-            target = "Ljava/lang/Runtime;getRuntime()Ljava/lang/Runtime;",
-            ordinal = 1,
-            shift = At.Shift.BEFORE),
+            target = "Lnet/minecraft/client/resources/ResourcePackRepository;getDirResourcepacks()Ljava/io/File;",
+            shift = At.Shift.BY,
+            by = 2),
         cancellable = true)
-    private void patcher$fixFolderOpening(CallbackInfo ci) throws IOException {
-        Desktop.getDesktop().open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks());
-        ci.cancel();
+    private void patcher$fixFolderOpening(CallbackInfo ci) {
+        if (UDesktop.open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks())) {
+            ci.cancel();
+        }
     }
-    //#endif
-
-    //#if MC==11202
-    //$$ @Inject(
-    //$$     method = "actionPerformed",
-    //$$     at =
-    //$$     @At(
-    //$$         value = "INVOKE",
-    //$$         target = "Lnet/minecraft/client/renderer/OpenGlHelper;openFile(Ljava/io/File;)V",
-    //$$         shift = At.Shift.BEFORE),
-    //$$     cancellable = true)
-    //$$ private void patcher$fixFolderOpening(CallbackInfo ci) {
-    //$$     if (Util.getOSType() == Util.EnumOS.WINDOWS) {
-    //$$         try {
-    //$$             Desktop.getDesktop().open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks());
-    //$$         } catch (Exception ignored) {}
-    //$$         ci.cancel();
-    //$$     }
-    //$$ }
-    //#endif
 
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
@@ -1,0 +1,32 @@
+package club.sk1er.patcher.mixins.bugfixes;
+
+import net.minecraft.client.gui.GuiScreenResourcePacks;
+import org.spongepowered.asm.mixin.Mixin;
+//#if MC==10809
+import net.minecraft.client.Minecraft;
+import org.spongepowered.asm.mixin.injection.At;
+import org.spongepowered.asm.mixin.injection.Inject;
+import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.awt.Desktop;
+import java.io.IOException;
+//#endif
+
+@Mixin(GuiScreenResourcePacks.class)
+public class GuiScreenResourcePacksMixin_FixOpenPackFolder {
+    //#if MC==10809
+    @Inject(
+        method = "actionPerformed",
+        at =
+        @At(
+            value = "INVOKE",
+            target = "Ljava/lang/Runtime;getRuntime()Ljava/lang/Runtime;",
+            ordinal = 1,
+            shift = At.Shift.BEFORE),
+        cancellable = true)
+    private void patcher$fixFolderOpening(CallbackInfo ci) throws IOException {
+        Desktop.getDesktop().open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks());
+        ci.cancel();
+    }
+    //#endif
+}

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
@@ -2,14 +2,20 @@ package club.sk1er.patcher.mixins.bugfixes;
 
 import net.minecraft.client.gui.GuiScreenResourcePacks;
 import org.spongepowered.asm.mixin.Mixin;
-//#if MC==10809
 import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.injection.At;
+import java.awt.Desktop;
+//#if MC==10809
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
-
-import java.awt.Desktop;
 import java.io.IOException;
+//#endif
+
+//#if MC==11202
+//$$ import org.spongepowered.asm.mixin.injection.Redirect;
+//$$ import net.minecraft.client.renderer.OpenGlHelper;
+//$$ import net.minecraft.util.Util;
+//$$ import java.io.File;
 //#endif
 
 @Mixin(GuiScreenResourcePacks.class)
@@ -29,4 +35,18 @@ public class GuiScreenResourcePacksMixin_FixOpenPackFolder {
         ci.cancel();
     }
     //#endif
+
+    //#if MC==11202
+    //$$ @Redirect(method = "actionPerformed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OpenGlHelper;openFile(Ljava/io/File;)V"))
+    //$$ private void patcher$fixFolderOpening(File file) {
+    //$$    if (Util.getOSType() == Util.EnumOS.WINDOWS) {
+    //$$        try {
+    //$$            Desktop.getDesktop().open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks());
+    //$$        } catch (Exception ignored) {}
+    //$$    } else {
+    //$$        OpenGlHelper.openFile(file);
+    //$$    }
+    //$$ }
+    //#endif
+
 }

--- a/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
+++ b/src/main/java/club/sk1er/patcher/mixins/bugfixes/GuiScreenResourcePacksMixin_FixOpenPackFolder.java
@@ -1,21 +1,20 @@
 package club.sk1er.patcher.mixins.bugfixes;
 
+import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiScreenResourcePacks;
 import org.spongepowered.asm.mixin.Mixin;
-import net.minecraft.client.Minecraft;
 import org.spongepowered.asm.mixin.injection.At;
-import java.awt.Desktop;
-//#if MC==10809
 import org.spongepowered.asm.mixin.injection.Inject;
 import org.spongepowered.asm.mixin.injection.callback.CallbackInfo;
+
+import java.awt.Desktop;
+
+//#if MC==10809
 import java.io.IOException;
 //#endif
 
 //#if MC==11202
-//$$ import org.spongepowered.asm.mixin.injection.Redirect;
-//$$ import net.minecraft.client.renderer.OpenGlHelper;
 //$$ import net.minecraft.util.Util;
-//$$ import java.io.File;
 //#endif
 
 @Mixin(GuiScreenResourcePacks.class)
@@ -37,15 +36,21 @@ public class GuiScreenResourcePacksMixin_FixOpenPackFolder {
     //#endif
 
     //#if MC==11202
-    //$$ @Redirect(method = "actionPerformed", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/OpenGlHelper;openFile(Ljava/io/File;)V"))
-    //$$ private void patcher$fixFolderOpening(File file) {
-    //$$    if (Util.getOSType() == Util.EnumOS.WINDOWS) {
-    //$$        try {
-    //$$            Desktop.getDesktop().open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks());
-    //$$        } catch (Exception ignored) {}
-    //$$    } else {
-    //$$        OpenGlHelper.openFile(file);
-    //$$    }
+    //$$ @Inject(
+    //$$     method = "actionPerformed",
+    //$$     at =
+    //$$     @At(
+    //$$         value = "INVOKE",
+    //$$         target = "Lnet/minecraft/client/renderer/OpenGlHelper;openFile(Ljava/io/File;)V",
+    //$$         shift = At.Shift.BEFORE),
+    //$$     cancellable = true)
+    //$$ private void patcher$fixFolderOpening(CallbackInfo ci) {
+    //$$     if (Util.getOSType() == Util.EnumOS.WINDOWS) {
+    //$$         try {
+    //$$             Desktop.getDesktop().open(Minecraft.getMinecraft().getResourcePackRepository().getDirResourcepacks());
+    //$$         } catch (Exception ignored) {}
+    //$$         ci.cancel();
+    //$$     }
     //$$ }
     //#endif
 

--- a/src/main/resources/patcher.mixins.json
+++ b/src/main/resources/patcher.mixins.json
@@ -58,6 +58,7 @@
     "bugfixes.GuiScreenOptionsSoundsMixin_PacketSpam",
     "bugfixes.GuiScreenResourcePacksMixin_ChangeTextPosition",
     "bugfixes.GuiScreenResourcePacksMixin_ClearHandles",
+    "bugfixes.GuiScreenResourcePacksMixin_FixOpenPackFolder",
     "bugfixes.GuiVideoSettingsMixin_MipmapSlider",
     "bugfixes.InventoryEffectRendererMixin_FixPotionEffectNumerals",
     "bugfixes.LayerArrowMixin_FixedBrightness",


### PR DESCRIPTION
There is a bug where if you have a space character on your folder path with Windows, when you click the "open resource pack folder" button it will not work. This PR fixes it see https://github.com/GTNewHorizons/Hodgepodge/pull/160