### PR TITLE
change: remove obsolete code

### DIFF
--- a/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
+++ b/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
@@ -166,19 +166,6 @@ public class PatcherMenuEditor {
                 realmsButton.enabled = false;
             }
         }
-
-        if (PatcherConfig.openToLanReplacement == 2 && gui instanceof GuiIngameMenu) {
-            EssentialConfig config = EssentialAPI.getConfig();
-            if (config.getOpenToFriends() && config.getEssentialFull() && EssentialAPI.getOnboardingData().hasAcceptedEssentialTOS()) {
-                for (GuiButton button : mcButtonList) {
-                    if (button != null && button.displayString.equals("Invite Friends")) {
-                        button.width = 200;
-                        button.xPosition = (gui.width / 2) - 100;
-                        break;
-                    }
-                }
-            }
-        }
     }
 
     @SubscribeEvent


### PR DESCRIPTION
~~This PR is a set of commits mostly consisting of changes I have made to my local build of Patcher over time.~~

~~The first commit removes code that seems to have been made irrelevant by changes to the full release of Essential last year.~~

~~The second commit simply uses ElementaVersion.V2 where possible; I haven't noticed any issues from this over the last several months or so but perhaps I have overlooked something.~~

~~The third commit contains some purely aesthetic changes, hiding the readable ping value in tab if it is the default 9999 that seems to be used when there is not a valid ping value. It also changes the duplicate message counter to be shown as `[x2]` rather than `(2)`; I would personally consider this to be more clear but it is not a very necessary change to be honest, mostly my own personal preference.~~

~~If wanted/needed, I can split these commits into separate PRs. I figured that I might as well see if these were wanted changes since I've sort of just had them sitting around for some time now.~~

This now just drops seemingly obsolete code.