### PR TITLE
Remove vertical view bobbing

### DIFF
--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -549,6 +549,13 @@ public class PatcherConfig extends Vigilant {
     public static boolean removeViewBobbing;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Remove Vertical Bobbing",
+        description = "While using View Bobbing, remove the vertical bobbing like in 1.14+.",
+        category = "Miscellaneous", subcategory = "General"
+    )
+    public static boolean removeVerticalViewBobbing;
+
+    @Property(
         type = PropertyType.SWITCH, name = "Remove Map Bobbing",
         description = "While using View Bobbing, remove the hand bobbing when holding a map.",
         category = "Miscellaneous", subcategory = "General"

--- a/src/main/java/club/sk1er/patcher/mixins/features/EntityRendererMixin_ViewBobbing.java
+++ b/src/main/java/club/sk1er/patcher/mixins/features/EntityRendererMixin_ViewBobbing.java
@@ -2,6 +2,7 @@ package club.sk1er.patcher.mixins.features;
 
 import club.sk1er.patcher.config.PatcherConfig;
 import club.sk1er.patcher.hooks.EntityRendererHook;
+import gg.essential.lib.mixinextras.injector.WrapWithCondition;
 import net.minecraft.client.renderer.EntityRenderer;
 import net.minecraft.client.settings.GameSettings;
 import org.spongepowered.asm.mixin.Dynamic;
@@ -24,5 +25,10 @@ public class EntityRendererMixin_ViewBobbing {
     @Redirect(method = "setupCameraTransform", at = @At(value = "FIELD", target = "Lnet/minecraft/client/settings/GameSettings;viewBobbing:Z", ordinal = 0))
     private boolean patcher$viewBobbing(GameSettings instance) {
         return instance.viewBobbing && !PatcherConfig.removeViewBobbing;
+    }
+
+    @WrapWithCondition(method = "setupViewBobbing", at = @At(value = "INVOKE", target = "Lnet/minecraft/client/renderer/GlStateManager;rotate(FFFF)V", ordinal = 2))
+    public boolean patcher$verticalViewBobbing(float angle, float x, float y, float z) {
+        return !PatcherConfig.removeVerticalViewBobbing;
     }
 }


### PR DESCRIPTION
Add setting to remove the vertical view bobbing.
This is especially useful when playing dropper.

Tested in both 1.8.9 and 1.12.2
Closes #158 