### PR TITLE
Fix Imgur links not being previewed and extra extension sometimes being added

### DIFF
--- a/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
+++ b/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
-import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 

--- a/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
+++ b/src/main/java/club/sk1er/patcher/screen/render/overlay/ImagePreview.java
@@ -28,6 +28,7 @@ import java.io.InputStream;
 import java.net.HttpURLConnection;
 import java.net.MalformedURLException;
 import java.net.URL;
+import java.util.Arrays;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
@@ -82,7 +83,7 @@ public class ImagePreview {
             return;
         }
 
-        if (value.contains("imgur.com/")) {
+        if (value.contains("imgur.com/") && !value.contains("i.imgur")) {
             final String[] split = value.split("/");
             value = String.format("https://i.imgur.com/%s.png", split[split.length - 1]);
         }
@@ -156,6 +157,10 @@ public class ImagePreview {
             connection.setUseCaches(true);
             connection.setInstanceFollowRedirects(true);
             connection.addRequestProperty("User-Agent", "Patcher Image Previewer");
+            if (url.contains("imgur")) {
+                // Prevents redirect to main website
+                connection.addRequestProperty("Referer", "https://imgur.com/");
+            }
             connection.setReadTimeout(15000);
             connection.setConnectTimeout(15000);
             connection.setDoOutput(true);


### PR DESCRIPTION
Imgur recently changed their website so that the direct links would redirect to the main website unless the `Referer` header was set to `https://imgur.com/`

This PR adds that header if the URL contains `imgur` and also prevents a duplicate `.png` extension being added to direct links (this didn't appear to break anything, it just bugged me when I was logging the URL)