### PR TITLE
fix: add dev mappings to ASM transformers

### DIFF
--- a/src/main/java/club/sk1er/patcher/asm/external/forge/render/ForgeHooksClientTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/external/forge/render/ForgeHooksClientTransformer.java
@@ -38,7 +38,7 @@ public class ForgeHooksClientTransformer implements PatcherTransformer {
                     if (next instanceof MethodInsnNode && next.getOpcode() == Opcodes.INVOKEVIRTUAL) {
                         final String methodInsnName = mapMethodNameFromNode(next);
                         if (methodInsnName.equals("getY") || methodInsnName.equals("func_177956_o")) {
-                            ((MethodInsnNode) next).name = "func_177952_p"; // getZ
+                            ((MethodInsnNode) next).name = isDevelopment() ? "getZ" : "func_177952_p";
                             break;
                         }
                     }

--- a/src/main/java/club/sk1er/patcher/asm/external/forge/render/screen/GuiModListTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/external/forge/render/screen/GuiModListTransformer.java
@@ -41,7 +41,7 @@ public class GuiModListTransformer implements PatcherTransformer {
                     // auto-closing stream
                     if (next instanceof MethodInsnNode && ((MethodInsnNode) next).name.equals("read")) {
                         ((MethodInsnNode) next).owner = "net/minecraft/client/renderer/texture/TextureUtil";
-                        ((MethodInsnNode) next).name = "func_177053_a"; // readBufferedImage
+                        ((MethodInsnNode) next).name = isDevelopment() ? "readBufferedImage" : "func_177053_a";
                         ((MethodInsnNode) next).desc = "(Ljava/io/InputStream;)Ljava/awt/image/BufferedImage;";
                         break;
                     }

--- a/src/main/java/club/sk1er/patcher/asm/external/forge/render/screen/GuiUtilsTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/external/forge/render/screen/GuiUtilsTransformer.java
@@ -34,14 +34,14 @@ public class GuiUtilsTransformer implements PatcherTransformer {
                             }
                         }
                     } else if (next instanceof VarInsnNode && next.getOpcode() == Opcodes.ISTORE && ((VarInsnNode) next).var == 17) {
-                        methodNode.instructions.insert(next, new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179097_i", "()V", false));
+                        methodNode.instructions.insert(next, new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "disableDepth" : "func_179097_i", "()V", false));
                     }
                 }
 
                 methodNode.instructions.insert(getMoveForward());
                 methodNode.instructions.insertBefore(
                     methodNode.instructions.getLast().getPrevious(),
-                    new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179121_F", "()V", false)
+                    new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "popMatrix" : "func_179121_F", "()V", false)
                 );
             }
         }
@@ -49,11 +49,11 @@ public class GuiUtilsTransformer implements PatcherTransformer {
 
     private InsnList getMoveForward() {
         InsnList insnList = new InsnList();
-        insnList.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179094_E", "()V", false));
+        insnList.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "pushMatrix" : "func_179094_E", "()V", false));
         insnList.add(new LdcInsnNode(0F));
         insnList.add(new LdcInsnNode(0F));
         insnList.add(new LdcInsnNode(-1F));
-        insnList.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179109_b", "(FFF)V", false));
+        insnList.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "translate" : "func_179109_b", "(FFF)V", false));
         return insnList;
     }
 }

--- a/src/main/java/club/sk1er/patcher/asm/external/mods/optifine/reflectionoptimizations/common/EntityRendererReflectionOptimizer.java
+++ b/src/main/java/club/sk1er/patcher/asm/external/mods/optifine/reflectionoptimizations/common/EntityRendererReflectionOptimizer.java
@@ -48,8 +48,8 @@ public class EntityRendererReflectionOptimizer implements PatcherTransformer {
     private InsnList optimizeReflection() {
         InsnList list = new InsnList();
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
-        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/EntityRenderer", "field_78531_r", "Lnet/minecraft/client/Minecraft;"));
-        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/Minecraft", "field_71462_r", "Lnet/minecraft/client/gui/GuiScreen;"));
+        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/EntityRenderer", isDevelopment() ? "mc" : "field_78531_r", "Lnet/minecraft/client/Minecraft;"));
+        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/Minecraft", isDevelopment() ? "currentScreen" : "field_71462_r", "Lnet/minecraft/client/gui/GuiScreen;"));
         list.add(new VarInsnNode(Opcodes.ILOAD, 8));
         list.add(new VarInsnNode(Opcodes.ILOAD, 9));
         list.add(new VarInsnNode(Opcodes.FLOAD, 1));

--- a/src/main/java/club/sk1er/patcher/asm/external/mods/optifine/reflectionoptimizations/common/ExtendedBlockStorageReflectionOptimizer.java
+++ b/src/main/java/club/sk1er/patcher/asm/external/mods/optifine/reflectionoptimizations/common/ExtendedBlockStorageReflectionOptimizer.java
@@ -16,7 +16,7 @@ public class ExtendedBlockStorageReflectionOptimizer implements PatcherTransform
     public void transform(ClassNode classNode, String name) {
         for (MethodNode methodNode : classNode.methods) {
             final String methodName = mapMethodName(classNode, methodNode);
-            if (methodName.equals("func_177484_a")) {
+            if (methodName.equals("set") || methodName.equals("func_177484_a")) {
                 final InsnList instructions = methodNode.instructions;
                 final Iterator<AbstractInsnNode> iterator = instructions.iterator();
                 while (iterator.hasNext()) {

--- a/src/main/java/club/sk1er/patcher/asm/external/mods/optifine/witherfix/EntityWitherTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/external/mods/optifine/witherfix/EntityWitherTransformer.java
@@ -45,7 +45,7 @@ public class EntityWitherTransformer implements PatcherTransformer {
     private InsnList checkVisibility() {
         InsnList list = new InsnList();
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
-        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/entity/boss/EntityWither", "func_82150_aj", "()Z", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/entity/boss/EntityWither", isDevelopment() ? "isInvisible" : "func_82150_aj", "()Z", false));
         LabelNode ifeq = new LabelNode();
         list.add(new JumpInsnNode(Opcodes.IFEQ, ifeq));
         list.add(new InsnNode(Opcodes.RETURN));

--- a/src/main/java/club/sk1er/patcher/asm/network/packet/S34PacketMapsTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/network/packet/S34PacketMapsTransformer.java
@@ -46,7 +46,7 @@ public class S34PacketMapsTransformer implements PatcherTransformer {
         }
     }
 
-    public static InsnList checkMapBytesLength() {
+    public InsnList checkMapBytesLength() {
         InsnList list = new InsnList();
 
         LabelNode checkSize = new LabelNode();
@@ -54,7 +54,7 @@ public class S34PacketMapsTransformer implements PatcherTransformer {
         list.add(new FieldInsnNode(
             Opcodes.GETFIELD,
             "net/minecraft/network/play/server/S34PacketMaps",
-            "field_179741_h",
+            isDevelopment() ? "mapDataBytes" : "field_179741_h",
             "[B"
         ));
         list.add(new InsnNode(Opcodes.DUP));

--- a/src/main/java/club/sk1er/patcher/asm/render/particle/EffectRendererTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/render/particle/EffectRendererTransformer.java
@@ -58,15 +58,15 @@ public class EffectRendererTransformer implements PatcherTransformer {
         list.add(new LdcInsnNode(0.017453292F));
         list.add(new VarInsnNode(Opcodes.FSTORE, 3));
         // actual fix for mc-74764
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", "func_178808_b", "()F", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", isDevelopment() ? "getRotationX" : "func_178808_b", "()F", false));
         list.add(new VarInsnNode(Opcodes.FSTORE, 4));
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", "func_178803_d", "()F", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", isDevelopment() ? "getRotationZ" : "func_178803_d", "()F", false));
         list.add(new VarInsnNode(Opcodes.FSTORE, 5));
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", "func_178805_e", "()F", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", isDevelopment() ? "getRotationYZ" : "func_178805_e", "()F", false));
         list.add(new VarInsnNode(Opcodes.FSTORE, 6));
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", "func_178807_f", "()F", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", isDevelopment() ? "getRotationXY" : "func_178807_f", "()F", false));
         list.add(new VarInsnNode(Opcodes.FSTORE, 7));
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", "func_178809_c", "()F", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/ActiveRenderInfo", isDevelopment() ? "getRotationXZ" : "func_178809_c", "()F", false));
         list.add(new VarInsnNode(Opcodes.FSTORE, 8));
         return list;
     }

--- a/src/main/java/club/sk1er/patcher/asm/render/screen/GuiChatTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/render/screen/GuiChatTransformer.java
@@ -158,15 +158,15 @@ public class GuiChatTransformer implements PatcherTransformer {
         LabelNode ifne = new LabelNode();
         list.add(new JumpInsnNode(Opcodes.IFNE, ifne));
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
-        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/gui/GuiChat", "field_146297_k", "Lnet/minecraft/client/Minecraft;"));
+        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/gui/GuiChat", isDevelopment() ? "mc" : "field_146297_k", "Lnet/minecraft/client/Minecraft;"));
         list.add(new InsnNode(Opcodes.ACONST_NULL));
-        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/client/Minecraft", "func_147108_a", "(Lnet/minecraft/client/gui/GuiScreen;)V", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/client/Minecraft", isDevelopment() ? "displayGuiScreen" : "func_147108_a", "(Lnet/minecraft/client/gui/GuiScreen;)V", false));
         list.add(new JumpInsnNode(Opcodes.GOTO, gotoInsn));
         list.add(ifne);
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
-        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/gui/GuiChat", "field_146415_a", "Lnet/minecraft/client/gui/GuiTextField;"));
+        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/gui/GuiChat", isDevelopment() ? "inputField" : "field_146415_a", "Lnet/minecraft/client/gui/GuiTextField;"));
         list.add(new LdcInsnNode(""));
-        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/client/gui/GuiTextField", "func_146180_a", "(Ljava/lang/String;)V", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/client/gui/GuiTextField", isDevelopment() ? "setText" : "func_146180_a", "(Ljava/lang/String;)V", false));
         list.add(new JumpInsnNode(Opcodes.GOTO, gotoInsn));
         list.add(ifeq);
         return list;
@@ -180,16 +180,16 @@ public class GuiChatTransformer implements PatcherTransformer {
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
         list.add(new FieldInsnNode(Opcodes.GETFIELD,
             "net/minecraft/client/gui/GuiChat",
-            "field_146415_a", // inputField
+            isDevelopment() ? "inputField" : "field_146415_a",
             "Lnet/minecraft/client/gui/GuiTextField;"));
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
         list.add(new FieldInsnNode(Opcodes.GETFIELD,
             "net/minecraft/client/gui/GuiChat",
-            "field_146409_v", // defaultInputFieldText
+            isDevelopment() ? "defaultInputFieldText" : "field_146409_v",
             "Ljava/lang/String;"));
         list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL,
             "net/minecraft/client/gui/GuiTextField",
-            "func_146180_a", // setText
+            isDevelopment() ? "setText" : "func_146180_a",
             "(Ljava/lang/String;)V",
             false));
         LabelNode gotoInsn = new LabelNode();
@@ -198,12 +198,12 @@ public class GuiChatTransformer implements PatcherTransformer {
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
         list.add(new FieldInsnNode(Opcodes.GETFIELD,
             "net/minecraft/client/gui/GuiChat",
-            "field_146415_a", // inputField
+            isDevelopment() ? "inputField" : "field_146415_a",
             "Lnet/minecraft/client/gui/GuiTextField;"));
         list.add(new VarInsnNode(Opcodes.ALOAD, 2));
         list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL,
             "net/minecraft/client/gui/GuiTextField",
-            "func_146180_a", // setText
+            isDevelopment() ? "setText" : "func_146180_a",
             "(Ljava/lang/String;)V",
             false));
         list.add(gotoInsn);
@@ -215,7 +215,7 @@ public class GuiChatTransformer implements PatcherTransformer {
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
         list.add(new FieldInsnNode(Opcodes.GETFIELD,
             "net/minecraft/client/gui/GuiChat",
-            "field_146415_a", // inputField
+            isDevelopment() ? "inputField" : "field_146415_a",
             "Lnet/minecraft/client/gui/GuiTextField;"));
         LabelNode ifnull = new LabelNode();
         list.add(new JumpInsnNode(Opcodes.IFNULL, ifnull));
@@ -232,11 +232,11 @@ public class GuiChatTransformer implements PatcherTransformer {
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
         list.add(new FieldInsnNode(Opcodes.GETFIELD,
             "net/minecraft/client/gui/GuiChat",
-            "field_146415_a", // inputField
+            isDevelopment() ? "inputField" : "field_146415_a",
             "Lnet/minecraft/client/gui/GuiTextField;"));
         list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL,
             "net/minecraft/client/gui/GuiTextField",
-            "func_146179_b", // getText
+            isDevelopment() ? "getText" : "func_146179_b",
             "()Ljava/lang/String;",
             false));
         LabelNode gotoInsn2 = new LabelNode();
@@ -251,7 +251,7 @@ public class GuiChatTransformer implements PatcherTransformer {
     private InsnList getOption(LabelNode ifne) {
         InsnList list = new InsnList();
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/gui/GuiChat", "func_146272_n", "()Z", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/gui/GuiChat", isDevelopment() ? "isShiftKeyDown" : "func_146272_n", "()Z", false));
         list.add(new FieldInsnNode(Opcodes.PUTFIELD, "net/minecraft/client/gui/GuiChat", "holdingShift", "Z"));
         list.add(getPatcherSetting("transparentChatInputField", "Z"));
         list.add(new JumpInsnNode(Opcodes.IFNE, ifne));

--- a/src/main/java/club/sk1er/patcher/asm/render/screen/InventoryEffectRendererTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/render/screen/InventoryEffectRendererTransformer.java
@@ -64,15 +64,15 @@ public class InventoryEffectRendererTransformer implements PatcherTransformer {
         list.add(new JumpInsnNode(Opcodes.IFEQ, ifeq));
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
-        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/InventoryEffectRenderer", "field_146294_l", // width
+        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/InventoryEffectRenderer", isDevelopment() ? "width" : "field_146294_l",
             "I"));
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
-        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/InventoryEffectRenderer", "field_146999_f", // xSize
+        list.add(new FieldInsnNode(Opcodes.GETFIELD, "net/minecraft/client/renderer/InventoryEffectRenderer", isDevelopment() ? "xSize" : "field_146999_f",
             "I"));
         list.add(new InsnNode(Opcodes.ISUB));
         list.add(new InsnNode(Opcodes.ICONST_2));
         list.add(new InsnNode(Opcodes.IDIV));
-        list.add(new FieldInsnNode(Opcodes.PUTFIELD, "net/minecraft/client/renderer/InventoryEffectRenderer", "field_147003_i", // guiLeft
+        list.add(new FieldInsnNode(Opcodes.PUTFIELD, "net/minecraft/client/renderer/InventoryEffectRenderer", isDevelopment() ? "guiLeft" : "field_147003_i",
             "I"));
         list.add(new InsnNode(Opcodes.RETURN));
         list.add(ifeq);

--- a/src/main/java/club/sk1er/patcher/asm/render/world/RenderGlobalTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/render/world/RenderGlobalTransformer.java
@@ -76,12 +76,12 @@ public class RenderGlobalTransformer implements PatcherTransformer {
                             if (next.getOpcode() == Opcodes.INVOKEVIRTUAL) {
                                 if (methodInsnName.equals("getClosestDistance") || methodInsnName.equals("func_177729_b")) {
                                     methodNode.instructions.insertBefore(next.getPrevious().getPrevious().getPrevious(),
-                                        new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179106_n", "()V", false));
+                                        new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "disableFog" : "func_179106_n", "()V", false));
                                 }
                             } else if (next.getOpcode() == Opcodes.INVOKESTATIC) {
                                 if ((methodInsnName.equals("depthMask") || methodInsnName.equals("func_179132_a")) && next.getPrevious().getOpcode() == Opcodes.ICONST_1) {
                                     methodNode.instructions.insert(next,
-                                        new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179127_m", "()V", false)
+                                        new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager",  isDevelopment() ? "enableFog" : "func_179127_m", "()V", false)
                                     );
                                 }
                             }

--- a/src/main/java/club/sk1er/patcher/asm/render/world/entity/RenderPlayerTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/render/world/entity/RenderPlayerTransformer.java
@@ -38,7 +38,7 @@ public class RenderPlayerTransformer implements PatcherTransformer {
         for (MethodNode methodNode : classNode.methods) {
             String methodName = mapMethodName(classNode, methodNode);
 
-            MethodInsnNode disableBlend = new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179084_k", "()V", false);
+            MethodInsnNode disableBlend = new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "disableBlend" : "func_179084_k", "()V", false);
             switch (methodName) {
                 //#if MC==10809
                 case "renderRightArm":
@@ -110,18 +110,18 @@ public class RenderPlayerTransformer implements PatcherTransformer {
         InsnList list = new InsnList();
         list.add(new VarInsnNode(Opcodes.ALOAD, 1));
         list.add(new FieldInsnNode(Opcodes.GETSTATIC, "net/minecraft/entity/player/EnumPlayerModelParts", "HAT", "Lnet/minecraft/entity/player/EnumPlayerModelParts;"));
-        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/client/entity/AbstractClientPlayer", "func_175148_a", "(Lnet/minecraft/entity/player/EnumPlayerModelParts;)Z", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKEVIRTUAL, "net/minecraft/client/entity/AbstractClientPlayer", isDevelopment() ? "func_175148_a" : "isWearing", "(Lnet/minecraft/entity/player/EnumPlayerModelParts;)Z", false));
         return list;
     }
 
-    public static InsnList enableBlend() {
+    public InsnList enableBlend() {
         InsnList list = new InsnList();
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179147_l", "()V", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "enableBlend" : "func_179147_l", "()V", false));
         list.add(new IntInsnNode(Opcodes.SIPUSH, GL11.GL_SRC_ALPHA));
         list.add(new IntInsnNode(Opcodes.SIPUSH, GL11.GL_ONE_MINUS_SRC_ALPHA));
         list.add(new InsnNode(Opcodes.ICONST_1));
         list.add(new InsnNode(Opcodes.ICONST_0));
-        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", "func_179120_a", "(IIII)V", false));
+        list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "net/minecraft/client/renderer/GlStateManager", isDevelopment() ? "tryBlendFuncSeparate" : "func_179120_a", "(IIII)V", false));
         return list;
     }
 }

--- a/src/main/java/club/sk1er/patcher/asm/render/world/entity/RenderWitherTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/render/world/entity/RenderWitherTransformer.java
@@ -45,7 +45,7 @@ public class RenderWitherTransformer implements PatcherTransformer {
         list.add(new VarInsnNode(Opcodes.ALOAD, 0));
         list.add(new VarInsnNode(Opcodes.FLOAD, 3));
         list.add(new MethodInsnNode(Opcodes.INVOKESTATIC, "java/lang/Math", "abs", "(F)F", false));
-        list.add(new FieldInsnNode(Opcodes.PUTFIELD, "net/minecraft/client/renderer/entity/RenderWither", "field_76989_e", "F"));
+        list.add(new FieldInsnNode(Opcodes.PUTFIELD, "net/minecraft/client/renderer/entity/RenderWither",  isDevelopment() ? "shadowSize" : "field_76989_e", "F"));
         return list;
     }
 }

--- a/src/main/java/club/sk1er/patcher/asm/render/world/entity/RenderXPOrbTransformer.java
+++ b/src/main/java/club/sk1er/patcher/asm/render/world/entity/RenderXPOrbTransformer.java
@@ -66,7 +66,7 @@ public class RenderXPOrbTransformer implements PatcherTransformer {
         list.add(new InsnNode(Opcodes.FCONST_0));
         list.add(new MethodInsnNode(Opcodes.INVOKESTATIC,
             "net/minecraft/client/renderer/GlStateManager",
-            "func_179109_b", // translate
+            isDevelopment() ? "translate" : "func_179109_b",
             "(FFF)V",
             false));
         return list;

--- a/src/main/kotlin/club/sk1er/patcher/asm/external/optifine/WorldVertexBufferUploaderTransformer.kt
+++ b/src/main/kotlin/club/sk1er/patcher/asm/external/optifine/WorldVertexBufferUploaderTransformer.kt
@@ -27,15 +27,28 @@ class WorldVertexBufferUploaderTransformer : PatcherTransformer {
     private val vertexFormatElement = "net/minecraft/client/renderer/vertex/VertexFormatElement"
     private val oldOptifine = ClassTransformer.optifineVersion == "I7"
     private val sVertexBuilder = if (oldOptifine) "shadersmod/client/SVertexBuilder" else "net/optifine/shaders/SVertexBuilder"
+    private val mapping = mapOf(
+        "func_178989_h" to "getVertexCount",
+        "func_178979_i" to "getDrawMode",
+        "func_178973_g" to "getVertexFormat",
+        "func_177338_f" to "getNextOffset",
+        "func_178966_f" to "getByteBuffer",
+        "func_177343_g" to "getElements",
+        "func_177375_c" to "getUsage",
+        "func_178965_a" to "reset"
+    )
+
+    private val String.environmentName: String
+        inline get() = if (!isDevelopment) this else mapping.getOrElse(this) { throw IllegalArgumentException("No mapping for $this")}
 
     private fun removeReflectionCall() = assembleBlock {
         aload_1
-        invokevirtual(worldRenderer, "func_178989_h", int)
+        invokevirtual(worldRenderer, "func_178989_h".environmentName, int)
         ifle(L["1"])
 
         if (!oldOptifine) {
             aload_1
-            invokevirtual(worldRenderer, "func_178979_i", int)
+            invokevirtual(worldRenderer, "func_178979_i".environmentName, int)
             bipush(7)
             if_icmpne(L["3"])
             invokestatic("Config", "isQuadsToTriangles", boolean)
@@ -46,16 +59,16 @@ class WorldVertexBufferUploaderTransformer : PatcherTransformer {
         }
 
         aload_1
-        invokevirtual(worldRenderer, "func_178973_g", vertexFormat)
+        invokevirtual(worldRenderer, "func_178973_g".environmentName, vertexFormat)
         astore_2
         aload_2
-        invokevirtual(vertexFormat, "func_177338_f", int)
+        invokevirtual(vertexFormat, "func_177338_f".environmentName, int)
         istore_3
         aload_1
-        invokevirtual(worldRenderer, "func_178966_f", ByteBuffer::class)
+        invokevirtual(worldRenderer, "func_178966_f".environmentName, ByteBuffer::class)
         astore(4)
         aload_2
-        invokevirtual(vertexFormat, "func_177343_g", List::class)
+        invokevirtual(vertexFormat, "func_177343_g".environmentName, List::class)
         astore(5)
         iconst_0
         istore(6)
@@ -70,7 +83,7 @@ class WorldVertexBufferUploaderTransformer : PatcherTransformer {
         checkcast(vertexFormatElement)
         astore(7)
         aload(7)
-        invokevirtual(vertexFormatElement, "func_177375_c", "$vertexFormatElement\$EnumUsage" as TypeLike)
+        invokevirtual(vertexFormatElement, "func_177375_c".environmentName, "$vertexFormatElement\$EnumUsage" as TypeLike)
         aload(2)
         iload(6)
         iload(3)
@@ -91,19 +104,19 @@ class WorldVertexBufferUploaderTransformer : PatcherTransformer {
         invokestatic("Config", "isShaders", boolean)
         ifeq(L["18"])
         aload_1
-        invokevirtual(worldRenderer, "func_178979_i", int)
+        invokevirtual(worldRenderer, "func_178979_i".environmentName, int)
         iconst_0
         aload_1
-        invokevirtual(worldRenderer, "func_178989_h", int)
+        invokevirtual(worldRenderer, "func_178989_h".environmentName, int)
         aload_1
         invokestatic(sVertexBuilder, "drawArrays", void, int, int, int, worldRenderer)
         goto(L["17"])
         +L["18"]
         aload_1
-        invokevirtual(worldRenderer, "func_178979_i", int)
+        invokevirtual(worldRenderer, "func_178979_i".environmentName, int)
         iconst_0
         aload_1
-        invokevirtual(worldRenderer, "func_178989_h", int)
+        invokevirtual(worldRenderer, "func_178989_h".environmentName, int)
         invokestatic(GL11::class, "glDrawArrays", void, int, int, int)
         +L["17"]
         iconst_0
@@ -121,7 +134,7 @@ class WorldVertexBufferUploaderTransformer : PatcherTransformer {
         checkcast(vertexFormatElement)
         astore(9)
         aload(9)
-        invokevirtual(vertexFormatElement, "func_177375_c", "$vertexFormatElement\$EnumUsage" as TypeLike)
+        invokevirtual(vertexFormatElement, "func_177375_c".environmentName, "$vertexFormatElement\$EnumUsage" as TypeLike)
         aload_2
         iload(7)
         iload_3
@@ -131,7 +144,7 @@ class WorldVertexBufferUploaderTransformer : PatcherTransformer {
         goto(L["21"])
         +L["1"]
         aload_1
-        invokevirtual(worldRenderer, "func_178965_a", void)
+        invokevirtual(worldRenderer, "func_178965_a".environmentName, void)
         _return
     }
 }


### PR DESCRIPTION
Allows for starting Minecraft development environment with Patcher.

Doesn't fix issues with Mixin remapping, but game still launches for debugging.