### PR TITLE
Hide `inventoryscale` command alias from autocompletion

### DIFF
--- a/src/main/java/club/sk1er/patcher/commands/InventoryScaleCommand.java
+++ b/src/main/java/club/sk1er/patcher/commands/InventoryScaleCommand.java
@@ -21,6 +21,6 @@ public class InventoryScaleCommand extends Command {
     @Nullable
     @Override
     public Set<Alias> getCommandAliases() {
-        return Collections.singleton(new Alias("inventoryscale"));
+        return Collections.singleton(new Alias("inventoryscale", true));
     }
 }


### PR DESCRIPTION
Hide the `inventoryscale` alias, just like `invscale`.