### PR TITLE
Hide broadcast settings button

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,6 +164,7 @@
 - **GUI Crosshair** - Stop rendering the crosshair when in a GUI.
 - **Startup Notification** - Notify how long the game took to start. *default
 - **Clean Main Menu** - Remove the Realms button on the main menu as it's useless on 1.8.9. *default
+- **Clean Options Menu** - Remove the twitch broadcast button on the options menu. *default
 - **Open to LAN Replacement** - Modify the Open to LAN button to either redirect to the server list or be removed.
 - **Smart Disconnect -** Choose between disconnecting or relogging when clicking the disconnect button. (Only works on multiplayer servers)
 - **Image Preview** - Preview image links when hovering over a supported URL. Press shift to use fullscreen and Control to render in native image resolution. (Currently supported: Imgur, Discord, Badlion screenshots)

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -1359,8 +1359,8 @@ public class PatcherConfig extends Vigilant {
             Function0<Boolean> minecraft112 = () -> ForgeVersion.mcVersion.equals("1.12.2");
             Arrays.asList(
                 "resourceExploitFix", "newKeybindHandling", "separateResourceLoading", "futureHitBoxes",
-                "leftHandInFirstPerson", "extendedChatLength", "chatPosition",
-                "parallaxFix", "crosshairPerspective", "extendChatBackground", "vanillaGlassPanes"
+                "leftHandInFirstPerson", "extendedChatLength", "chatPosition", "parallaxFix",
+                "crosshairPerspective", "extendChatBackground", "cleanOptionsMenu", "vanillaGlassPanes"
             ).forEach(property -> hidePropertyIf(property, minecraft112));
 
             hidePropertyIf("keyboardLayout", () -> !SystemUtils.IS_OS_LINUX);

--- a/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/PatcherConfig.java
@@ -1099,6 +1099,13 @@ public class PatcherConfig extends Vigilant {
     public static boolean cleanMainMenu = true;
 
     @Property(
+        type = PropertyType.SWITCH, name = "Clean Options Menu",
+        description = "Remove the twitch broadcast button on the options menu.",
+        category = "Screens", subcategory = "General"
+    )
+    public static boolean cleanOptionsMenu = true;
+
+    @Property(
         type = PropertyType.SELECTOR, name = "Open to LAN Replacement",
         description = "Modify the Open to LAN button to either redirect to the server list or be removed.",
         category = "Screens", subcategory = "General",

--- a/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
+++ b/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
@@ -18,6 +18,7 @@ import net.minecraft.client.Minecraft;
 import net.minecraft.client.gui.GuiButton;
 import net.minecraft.client.gui.GuiIngameMenu;
 import net.minecraft.client.gui.GuiMainMenu;
+import net.minecraft.client.gui.GuiOptions;
 import net.minecraft.client.gui.GuiScreen;
 import net.minecraft.client.gui.GuiScreenOptionsSounds;
 import net.minecraft.client.gui.GuiScreenResourcePacks;
@@ -85,7 +86,22 @@ public class PatcherMenuEditor {
                     }
                 }
             }
-        } else if (gui instanceof GuiScreenResourcePacks) {
+        }
+        //#if MC==10809
+        else if (gui instanceof GuiOptions && PatcherConfig.cleanOptionsMenu) {
+            for (GuiButton button : mcButtonList) {
+                if (button.displayString.equals(I18n.format("options.stream"))) {
+                    button.visible = false;
+                    button.enabled = false;
+                } else if (button.displayString.equals(I18n.format("options.sounds"))) {
+                    button.xPosition = gui.width / 2 + 5;
+                } else if (button.displayString.equals(I18n.format("options.skinCustomisation"))) {
+                    button.yPosition = gui.height / 6 + 72 - 6;
+                }
+            }
+        }
+        //#endif
+        else if (gui instanceof GuiScreenResourcePacks) {
             if (!Loader.isModLoaded("ResourcePackOrganizer")) {
                 for (GuiButton button : mcButtonList) {
                     button.width = 200;

--- a/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
+++ b/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
@@ -94,9 +94,9 @@ public class PatcherMenuEditor {
                     button.visible = false;
                     button.enabled = false;
                 } else if (button.displayString.equals(I18n.format("options.sounds"))) {
-                    button.xPosition = gui.width / 2 + 5;
+                    button.xPosition = width / 2 + 5;
                 } else if (button.displayString.equals(I18n.format("options.skinCustomisation"))) {
-                    button.yPosition = gui.height / 6 + 72 - 6;
+                    button.yPosition = height / 6 + 72 - 6;
                 }
             }
         }


### PR DESCRIPTION
Hides the `Broadcast Settings` button since its useless and moves the music and skin customization buttons to account for the layout change.

Tested, but not sure how it will cope with other mods changing the menu.