### PR TITLE
Allow opening the config gui from the mod menu

### DIFF
--- a/src/main/java/club/sk1er/patcher/Patcher.java
+++ b/src/main/java/club/sk1er/patcher/Patcher.java
@@ -80,7 +80,7 @@ import java.util.TreeSet;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
 
-@Mod(modid = "patcher", name = "Patcher", version = Patcher.VERSION, clientSideOnly = true)
+@Mod(modid = "patcher", name = "Patcher", version = Patcher.VERSION, clientSideOnly = true, guiFactory = "club.sk1er.patcher.config.DummyForgeConfig")
 public class Patcher {
 
     @Mod.Instance("patcher")

--- a/src/main/java/club/sk1er/patcher/config/DummyForgeConfig.java
+++ b/src/main/java/club/sk1er/patcher/config/DummyForgeConfig.java
@@ -1,0 +1,49 @@
+package club.sk1er.patcher.config;
+
+import club.sk1er.patcher.Patcher;
+import gg.essential.api.utils.GuiUtil;
+import net.minecraft.client.Minecraft;
+import net.minecraft.client.gui.GuiScreen;
+import net.minecraftforge.fml.client.IModGuiFactory;
+
+import java.util.Set;
+
+@SuppressWarnings("unused")
+public class DummyForgeConfig implements IModGuiFactory {
+    @Override
+    public void initialize(Minecraft minecraft) {
+    }
+
+    @Override
+    public Set<RuntimeOptionCategoryElement> runtimeGuiCategories() {
+        return null;
+    }
+
+    //#if MC==10809
+    @Override
+    public Class<? extends GuiScreen> mainConfigGuiClass() {
+        return DummyForgeConfigGUI.class;
+    }
+
+    @Override
+    public RuntimeOptionGuiHandler getHandlerFor(RuntimeOptionCategoryElement runtimeOptionCategoryElement) {
+        return null;
+    }
+    //#else
+    //$$ @Override
+    //$$ public boolean hasConfigGui() {
+    //$$     return true;
+    //$$ }
+
+    //$$ @Override
+    //$$ public GuiScreen createConfigGui(GuiScreen guiScreen) {
+    //$$     return Patcher.instance.getPatcherConfig().gui();
+    //$$ }
+    //#endif
+
+    public static class DummyForgeConfigGUI extends GuiScreen {
+        public DummyForgeConfigGUI(GuiScreen parent) {
+            GuiUtil.open(Patcher.instance.getPatcherConfig().gui());
+        }
+    }
+}


### PR DESCRIPTION
Makes the config button in the mod list functional, allowing to edit options while not in game.
Pressing escape currently closes the whole menu instead of going back to the mod list, as i haven't found a good way to do that.

Tested in both 1.8.9 and 1.12.2.