### PR TITLE
Update actions and add upload artifact

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -4,7 +4,17 @@ on:
   push:
     branches:
       - "**"
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE.md'
+      - '.editorconfig'
+      - '.gitignore'
   pull_request:
+    paths-ignore:
+      - 'README.md'
+      - 'LICENSE.md'
+      - '.editorconfig'
+      - '.gitignore'
 
 concurrency:
   # Maximum of one running workflow per pull request source branch
@@ -18,16 +28,16 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
-      - uses: gradle/wrapper-validation-action@v1
+      - uses: gradle/actions/wrapper-validation@v4
 
-      - uses: actions/setup-java@v2
+      - uses: actions/setup-java@v4
         with:
           distribution: "temurin"
           java-version: "17"
 
-      - uses: actions/cache@v2
+      - uses: actions/cache@v4
         with:
           path: |
             ~/.gradle/caches
@@ -38,3 +48,8 @@ jobs:
             ${{ runner.os }}-gradle-v2-
 
       - run: ./gradlew --no-daemon build
+
+      - uses: actions/upload-artifact@v4
+        with:
+          name: build
+          path: versions/*/build/libs/*.jar


### PR DESCRIPTION
Updates all the github actions to latest and adds the upload artifact action to upload the build jars.

This is necessary or they [will break on march 1st](https://github.com/actions/cache/discussions/1510).