### PR TITLE
More accurate load time

### DIFF
--- a/src/main/java/club/sk1er/patcher/Patcher.java
+++ b/src/main/java/club/sk1er/patcher/Patcher.java
@@ -17,7 +17,6 @@ import club.sk1er.patcher.screen.render.overlay.ImagePreview;
 import club.sk1er.patcher.screen.render.overlay.OverlayHandler;
 import club.sk1er.patcher.screen.render.overlay.metrics.MetricsRenderer;
 import club.sk1er.patcher.screen.render.title.TitleFix;
-import club.sk1er.patcher.tweaker.PatcherTweaker;
 import club.sk1er.patcher.util.chat.ChatHandler;
 import club.sk1er.patcher.util.enhancement.EnhancementManager;
 import club.sk1er.patcher.util.enhancement.ReloadListener;
@@ -172,13 +171,6 @@ public class Patcher {
         Notifications notifications = EssentialAPI.getNotifications();
         this.detectIncompatibilities(activeModList, notifications);
         this.detectReplacements(activeModList, notifications);
-
-        long time = (System.currentTimeMillis() - PatcherTweaker.clientLoadTime) / 1000L;
-        if (PatcherConfig.startupNotification) {
-            notifications.push("Minecraft Startup", "Minecraft started in " + time + " seconds.");
-        }
-
-        logger.info("Minecraft started in {} seconds.", time);
 
         //noinspection ConstantConditions
         if (!ForgeVersion.mcVersion.equals("1.8.9") || ForgeVersion.getVersion().contains("2318")) return;

--- a/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
+++ b/src/main/java/club/sk1er/patcher/screen/PatcherMenuEditor.java
@@ -5,6 +5,7 @@ import club.sk1er.patcher.config.PatcherConfig;
 import club.sk1er.patcher.mixins.accessors.GuiMainMenuAccessor;
 import club.sk1er.patcher.screen.disconnect.SmartDisconnectScreen;
 import club.sk1er.patcher.screen.quit.ConfirmQuitScreen;
+import club.sk1er.patcher.tweaker.PatcherTweaker;
 import gg.essential.api.EssentialAPI;
 import gg.essential.api.config.EssentialConfig;
 import gg.essential.elementa.ElementaVersion;
@@ -32,6 +33,7 @@ import java.util.List;
 
 public class PatcherMenuEditor {
     private boolean tripped = false;
+    private boolean isFirstLaunch = true;
 
     private final Minecraft mc = Minecraft.getMinecraft();
     private final int[] sequence = new int[]{
@@ -76,6 +78,14 @@ public class PatcherMenuEditor {
         final int height = gui.height;
 
         if (gui instanceof GuiMainMenu) {
+            if (isFirstLaunch) {
+                long time = (System.currentTimeMillis() - PatcherTweaker.clientLoadTime);
+                if (PatcherConfig.startupNotification) {
+                    EssentialAPI.getNotifications().push("Minecraft Startup", "Minecraft started in " + time / 1000L + " seconds.");
+                }
+                Patcher.instance.getLogger().info("Minecraft started in {}ms.", time);
+                isFirstLaunch = false;
+            }
             if (PatcherConfig.cleanMainMenu) {
                 realmsButton = ((GuiMainMenuAccessor) gui).getRealmsButton();
                 for (GuiButton button : mcButtonList) {


### PR DESCRIPTION
Moves the startup detection to loading the main menu for the first time, as that is a more accurate indicator that the game has finished loading.

Tested in both 1.8.9 and 1.12.2.