### PR TITLE
Don't delete screenshot if copy failed

### DIFF
--- a/src/main/java/club/sk1er/patcher/util/screenshot/AsyncScreenshots.java
+++ b/src/main/java/club/sk1er/patcher/util/screenshot/AsyncScreenshots.java
@@ -204,13 +204,12 @@ public class AsyncScreenshots implements Runnable {
         public void handle() {
             try {
                 final File favoritedScreenshots = getTimestampedPNGFileForDirectory(new File("./favorite_screenshots"));
-                screenshot.delete();
-
                 if (!favoritedScreenshots.exists()) {
                     favoritedScreenshots.mkdirs();
                 }
 
                 ImageIO.write(image, "png", favoritedScreenshots);
+                screenshot.delete();
                 ChatUtilities.sendNotification("Screenshot Manager", "&e" + screenshot.getName() + " has been favorited.");
             } catch (Throwable e) {
                 ChatUtilities.sendNotification("Screenshot Manager", "&cFailed to favorite screenshot, maybe the file was moved/deleted?");


### PR DESCRIPTION
Moves the file deletion to after the write, to avoid data loss in case the write fails.
Can easily be tested by making the `favorite_screenshots` directory not writable.